### PR TITLE
Reset of Ace UndoManager to avoid resetting document to empty

### DIFF
--- a/sharejs-ace/client.coffee
+++ b/sharejs-ace/client.coffee
@@ -20,6 +20,9 @@ class ShareJSAceConnector extends ShareJSConnector
     doc.attach_ace(@ace)
     @ace.setReadOnly(false)
     @connectCallback?(@ace)
+    #Reset the undo manager, such that ctrl-z does not lead to an empty document
+    UndoManager = require("ace/undomanager").UndoManager;
+    @ace.getSession().setUndoManager(new UndoManager());
 
   disconnect: ->
     # Detach ace editor, if any

--- a/sharejs-ace/package.js
+++ b/sharejs-ace/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: "mizzao:sharejs-ace",
   summary: "ShareJS with the Ace Editor",
-  version: "1.1.8",
+  version: "1.2.0",
   git: "https://github.com/mizzao/meteor-sharejs.git"
 });
 


### PR DESCRIPTION
With this change the document can only be resetet to the status of the document on connect. This avoids that the document can be reset to a empty one.