### PR TITLE
Fix error loading browserchannel/BCSocket

### DIFF
--- a/sharejs-base/package.js
+++ b/sharejs-base/package.js
@@ -9,7 +9,8 @@ Npm.depends({
   // Fork of 0.6.3 that doesn't require("mongodb"):
   // https://github.com/meteor/meteor/issues/532#issuecomment-82635979
   // Includes "Failed to parse" bugfix
-  share: "https://github.com/qeek/sharejs-tmp-fork/tarball/94c059bd4da24de8e6e90fb83484dd9c7b0efd59"
+  share: "https://github.com/qeek/sharejs-tmp-fork/tarball/94c059bd4da24de8e6e90fb83484dd9c7b0efd59",
+  browserchannel: '1.2.0'
 });
 
 Package.onUse(function (api) {


### PR DESCRIPTION
Unfortunately 0.10.1 contains a bug in loading BCSocket from the node module `browserchannel` that `share` depends on.

I didn't spot it because I only tested my pull request as a local package in `<project>/packages`. I've now tested this modification with a published package and it works correctly and fixes the issue.

FYI 0.10.1 _does not work at all_ as it is currently published.