### PR TITLE
 Use Meteor.absoluteUrl to fix mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,21 @@ Template.foo.config = function () {
 
 See this [example config file](settings-example.json) for the various settings that you can use.
 
+If you are running on mobile via Meteor's Cordova, you'll also need to specify a `cors` rule to allow the mobile device's `localhost` server to make a cross-origin request, such as the following:
+
+```json
+{
+  "sharejs": {
+    "options": {
+      "browserChannel": {
+        "cors": "*"
+      },
+      ...
+    }
+  }
+}
+```
+
 ### Persistence
 
 By default, the documents and edit operations will be persisted in Meteor's Mongo database. Mongo is the recommended usage as you don't need a separate database and user integration is supported. `"opsCollectionPerDoc": false` can be useful to set if you don't want a separate ops collection for each document.

--- a/sharejs-base/sharejs-client.js
+++ b/sharejs-base/sharejs-client.js
@@ -13,7 +13,7 @@ export class ShareJSConnector {
 
     getOptions() {
         return {
-            origin: Meteor.absoluteUrl('/channel')
+            origin: Meteor.absoluteUrl('channel')
         };
     };
 

--- a/sharejs-base/sharejs-client.js
+++ b/sharejs-base/sharejs-client.js
@@ -13,7 +13,7 @@ export class ShareJSConnector {
 
     getOptions() {
         return {
-            origin: '//' + window.location.host + '/channel'
+            origin: Meteor.absoluteUrl('/channel')
         };
     };
 


### PR DESCRIPTION
On mobile (e.g. Android), `window.location` is `http://localhost:port` (a local mirror server running on but `Meteor.absoluteUrl()` returns the actual remote server, which is what we want for ShareJS.  I've tested that this small patch works on both mobile and on regular web browsers.

This setup also requires tweaking with CORS settings.  I've added some documentation to the README about how this can be done (but didn't change the sample settings file, as many people may want to do this).