### PR TITLE
Remove `ShareJS ||` in ShareJS declaration

### DIFF
--- a/sharejs-base/sharejs-server.js
+++ b/sharejs-base/sharejs-server.js
@@ -5,7 +5,7 @@ import { Meteor } from 'meteor/meteor';
 
 const Future = Npm.require('fibers/future');
 
-export const ShareJS = ShareJS || {};
+export const ShareJS = {};
 // See docs for options. Uses mongo by default to enable persistence.
 
 // Using special options from https://github.com/share/ShareJS/blob/master/src/server/index.coffee


### PR DESCRIPTION
Seems necessary for Node 8 / Meteor 1.6.  Without this change, I get a `ShareJS undefined` error on this line in Meteor 1.6.