### PR TITLE
Fix immediate undo resetting to 'loading...' text

### DIFF
--- a/sharejs-codemirror/cm.js
+++ b/sharejs-codemirror/cm.js
@@ -57,7 +57,11 @@
       this.del(0, sharedoc.getText('\n').length);
       this.insert(0, editor.getValue());
     } else {
+      // Prevent immediate undo from going before initially loaded text.
+      var undoDepth = editor.getOption('undoDepth');
+      editor.setOption('undoDepth', 0);
       editor.setValue(sharedoc.getText());
+      editor.setOption('undoDepth', undoDepth);
     }
     check();
     suppress = false;


### PR DESCRIPTION
This mixes a bug in CodeMirror where, after the initial text loads and replaced 'loading...', pressing ctrl-Z undoes that change and goes back to the 'loading...' text. This bug was mentioned in:
* https://github.com/mizzao/meteor-sharejs/issues/35#issuecomment-73748075
* https://github.com/edemaine/coauthor/issues/278#issuecomment-467649194

The solution was to set the undo stack to size 0 before making the (first) change, then restoring the undo stack size.